### PR TITLE
Bump httpclient from 4.5 to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5</version>
+			<version>4.5.13</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Bumps httpclient from 4.5 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>