### PR TITLE
Bump commons-io from 1.4 to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.4</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Bumps commons-io from 1.4 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>